### PR TITLE
Fix rewirer of mod savedata being put with bad key into dictionary

### DIFF
--- a/ShapezShifter/src/ShapezShifter.Flow/SaveData/ModSaveDataExtensions.cs
+++ b/ShapezShifter/src/ShapezShifter.Flow/SaveData/ModSaveDataExtensions.cs
@@ -49,9 +49,7 @@ namespace ShapezShifter.Flow
         /// <param name="defaultDataFactory">A factory that creates a default instance of the data</param>
         public static void AttachSaveData<T>(this IMod mod, IFactory<T> defaultDataFactory)
         {
-            string dataName = typeof(T).FullName;
-            string assemblyName = mod.GetType().Assembly.GetName().Name;
-            string fullName = $"{assemblyName}-{dataName}.json";
+            string fullName = mod.ResolveId<T>();
             string fileName = $"{fullName}.json";
 
             var rewirer = new ModSaveDataRewirer<T>(

--- a/ShapezShifter/src/ShapezShifter.Flow/SaveData/ModSaveDataRewirer.cs
+++ b/ShapezShifter/src/ShapezShifter.Flow/SaveData/ModSaveDataRewirer.cs
@@ -36,12 +36,8 @@ namespace ShapezShifter.Flow
             {
                 throw new ArgumentException(message: "Filename cannot be null or empty", paramName: nameof(fileName));
             }
-
-            if (Path.HasExtension("json"))
-            {
-                fileName = Path.ChangeExtension(path: fileName, extension: "json");
-            }
-
+            
+            fileName = Path.ChangeExtension(path: fileName, extension: "json");
             FileName = fileName;
             DefaultDataFactory = defaultDataFactory;
             Logger = logger;


### PR DESCRIPTION
`ModSaveDataExtensions.AttachSaveData<T>(...)` constructs the key `fullname`, which is used for putting the `ActiveRewirer` into the `ModSaveDataExtensions.Rewirers` dictionary, with an extra `.json`. That crashes the game whenever `ModSaveDataExtensions.GetRewirer<T>(...)` is called (and also saves the mod's savedata into a file with double extension).

While looking at it, I also noticed that the `ModSaveDataRewirer` constructor tries to correct a potential incorrect file extension, but never gets to do it because it checks for the string `"json"` having an extension.