### PR TITLE
Fix environment variable logic

### DIFF
--- a/ShapezShifter/src/Main.cs
+++ b/ShapezShifter/src/Main.cs
@@ -33,7 +33,7 @@ namespace ShapezShifter
 
         private static void SetupPathEnvironmentVariable(ILogger logger)
         {
-            if (Application.isEditor || GameEnvironment.ShouldSetModFriendlyEnvironmentPath)
+            if (Application.isEditor || !GameEnvironment.ShouldSetModFriendlyEnvironmentPath)
             {
                 return;
             }


### PR DESCRIPTION
Fix the logic for the shapez shifter path environment variable only being set when the command line argument is not present. Should fix #9