### PR TITLE
fix upgrade not showing up in shop

### DIFF
--- a/ShapezShifter/src/ShapezShifter.Flow/AtomicExtender/Research/ISideUpgradeBuilder.cs
+++ b/ShapezShifter/src/ShapezShifter.Flow/AtomicExtender/Research/ISideUpgradeBuilder.cs
@@ -99,9 +99,13 @@ namespace ShapezShifter.Flow.Atomic
                 category: SideUpgradePresentationData.Category);
 
             progression._SideUpgrades.Add(upgrade);
+            progression._ShopItems.Add(upgrade);
 
             progression._AllUpgrades.Add(upgrade);
             progression._UpgradesById[upgrade.Id] = upgrade;
+
+            if (!progression._SideUpgradeCategories.Contains(upgrade.Category))
+                progression._SideUpgradeCategories.Add(upgrade.Category);
 
             return upgrade;
         }


### PR DESCRIPTION
fixes #15 

note this will cause another bug to surface that will make the game basically unplayable if any building in the shop is using the `GameImageId.Empty` (like the Diagonal Cutter example mod) because there is a bug within `GameData.GetImage` where it does not handle that value and so throws an exception. I have fixed that in my mod by patching that function to return `null` if `uniqueId.IsEmpty`